### PR TITLE
Fix: Reset flashcard to front when moving to next word

### DIFF
--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -882,7 +882,6 @@ const LearnTab = {
 
       this.sessionWords = response.data;
       this.currentWordIndex = 0;
-      this.isFlipped = false;
       this.sessionStats = {
         total: this.sessionWords.length,
         completed: 0,
@@ -909,6 +908,9 @@ const LearnTab = {
       this.endReviewSession();
       return;
     }
+
+    // Reset flip state before generating HTML to ensure new card shows front
+    this.isFlipped = false;
 
     const word = this.sessionWords[this.currentWordIndex];
     const container = document.querySelector('.learn-container');
@@ -995,7 +997,6 @@ const LearnTab = {
 
     // Re-setup controls
     this.setupLearnControls();
-    this.isFlipped = false;
   },
 
   flipCard() {

--- a/tests/integration/popup-integration.test.js
+++ b/tests/integration/popup-integration.test.js
@@ -1228,6 +1228,47 @@ describe('Popup Integration Tests', () => {
       });
     });
 
+    test('should reset flashcard to front when moving to next word after review action', async () => {
+      // Start review
+      const learnTab = document.querySelector('[data-tab="learn"]');
+      learnTab.click();
+
+      await waitFor(() => document.querySelector('#start-review-btn'));
+      document.querySelector('#start-review-btn').click();
+
+      await waitFor(() => document.querySelector('#flashcard'));
+
+      // Get first word
+      const firstWord = document.querySelector('.word-display').textContent;
+
+      // Flip the first card to show back
+      const flashcard = document.querySelector('#flashcard');
+      flashcard.click();
+
+      // Wait for card to be flipped
+      await waitFor(() => flashcard.classList.contains('flipped'));
+      expect(flashcard.classList.contains('flipped')).toBe(true);
+
+      // Click "known" button to move to next word
+      const knownBtn = document.querySelector('#known-btn');
+      knownBtn.click();
+
+      // Wait for next word to be displayed
+      await waitFor(() => {
+        const wordDisplay = document.querySelector('.word-display');
+        return wordDisplay && wordDisplay.textContent !== firstWord;
+      });
+
+      // Check that the new card is NOT flipped (should show front)
+      const newFlashcard = document.querySelector('#flashcard');
+      expect(newFlashcard.classList.contains('flipped')).toBe(false);
+
+      // Verify review actions are hidden for the new card
+      const reviewActions = document.querySelector('.review-actions');
+      expect(reviewActions.classList.contains('hidden')).toBe(true);
+      expect(reviewActions.classList.contains('visible')).toBe(false);
+    });
+
     test('should update nextReview date after review action', async () => {
       // Start review
       const learnTab = document.querySelector('[data-tab="learn"]');


### PR DESCRIPTION
## Summary
- Fixes #15 - Flashcard remains flipped when progressing to next word
- Reset isFlipped state before generating HTML to ensure new cards always show front side
- Add comprehensive test case to prevent regression

## Problem
When users click review action buttons (Known/Unknown/Skip/Mastered) in learning mode, if the current flashcard is showing its back side, the next card incorrectly displays its back side instead of starting from the front.

## Root Cause
The `displayCurrentWord()` function was resetting `this.isFlipped` AFTER generating the HTML (line 998), causing the new card's HTML to include the `flipped` class when it shouldn't.

## Solution
1. **Move isFlipped reset to the beginning of displayCurrentWord()** (line 913)
   - Ensures the flag is reset before HTML generation
   - New cards now always start showing the front side

2. **Remove duplicate isFlipped reset from startReviewSession()** (line 885)
   - No longer needed since displayCurrentWord() handles it

3. **Add test case** to verify the fix works correctly
   - Test flips first card, clicks review action, verifies next card shows front

## Test Plan
- [x] Added new test case that reproduces the bug and verifies the fix
- [x] All existing tests pass
- [x] Manual testing in browser confirms cards reset properly

🤖 Generated with [Claude Code](https://claude.ai/code)