### PR TITLE
fix: macOS Safariでpopupのtab-contentが表示されない問題を修正 (#52)

### DIFF
--- a/Shared (Extension)/Resources/popup.css
+++ b/Shared (Extension)/Resources/popup.css
@@ -916,7 +916,7 @@ h1, h2, h3, h4, h5, h6 {
 /* Responsive Design */
 
 /* iOS Safari Extension - Mobile viewport adjustments */
-@media (max-width: 600px) {
+@media only screen and (max-device-width: 600px) {
   /* Compact tab navigation for mobile */
   .tab-button {
     padding: var(--spacing-sm);

--- a/Shared (Extension)/Resources/popup.html
+++ b/Shared (Extension)/Resources/popup.html
@@ -10,16 +10,12 @@
         html, body {
             margin: 0;
             padding: 0;
-        }
-        
-        /* Desktop default size */
-        html, body {
             width: 600px;
             height: 700px;
         }
         
-        /* iOS Safari responsive design - for narrow viewports */
-        @media (max-width: 600px) {
+        /* Mobile devices (iPhone) - use device-width instead of viewport width */
+        @media only screen and (max-device-width: 600px) {
             html, body {
                 width: 100%;
                 height: 100vh;

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -916,7 +916,7 @@ h1, h2, h3, h4, h5, h6 {
 /* Responsive Design */
 
 /* iOS Safari Extension - Mobile viewport adjustments */
-@media (max-width: 600px) {
+@media only screen and (max-device-width: 600px) {
   /* Compact tab navigation for mobile */
   .tab-button {
     padding: var(--spacing-sm);

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -10,16 +10,12 @@
         html, body {
             margin: 0;
             padding: 0;
-        }
-        
-        /* Desktop default size */
-        html, body {
             width: 600px;
             height: 700px;
         }
         
-        /* iOS Safari responsive design - for narrow viewports */
-        @media (max-width: 600px) {
+        /* Mobile devices (iPhone) - use device-width instead of viewport width */
+        @media only screen and (max-device-width: 600px) {
             html, body {
                 width: 100%;
                 height: 100vh;


### PR DESCRIPTION
## 概要
Issue #52 を解決します。
macOS Safariでpopupを開いた時に`tab-content`の内容が表示されない問題を修正しました。

## 問題の原因
- メディアクエリ `@media (max-width: 600px)` がデスクトップSafariでも誤適用されていた
- Safari拡張機能のポップアップウィンドウの初期レンダリング時に、ビューポート幅が不定になることがある
- その結果、`height: 100vh`が適用され、コンテンツエリアの高さが0になっていた

## 修正内容
- メディアクエリを `max-width` から `max-device-width` に変更
- デバイスの物理的な幅で判定するようにし、ウィンドウサイズの変動に影響されないように修正

### 変更ファイル
- `src/popup/popup.html`: インラインスタイルのメディアクエリを修正
- `src/popup/popup.css`: レスポンシブデザインのメディアクエリを修正
- ビルド生成ファイル（`Shared (Extension)/Resources/`）も自動更新

## 動作確認
- [x] macOS Safariでpopupが600x700pxで正しく表示される
- [x] tab-contentの内容が表示される
- [x] タブ切り替えが正常に動作する

## テスト計画
- macOS Safariで拡張機能のポップアップを開き、全タブが正常に表示されることを確認
- 将来的にiOS Safariでもレスポンシブデザインが適用されることを想定した実装

Fixes #52

🤖 Generated with [Claude Code](https://claude.ai/code)