### PR TITLE
fix: resolve macOS Safari popup width issue #54

### DIFF
--- a/Shared (Extension)/Resources/popup.css
+++ b/Shared (Extension)/Resources/popup.css
@@ -77,11 +77,6 @@
   padding: 0;
 }
 
-html {
-  width: 400px;
-  height: 600px;
-}
-
 body {
   font-family: -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Segoe UI', system-ui, sans-serif;
   font-size: 14px;

--- a/Shared (Extension)/Resources/popup.html
+++ b/Shared (Extension)/Resources/popup.html
@@ -7,17 +7,26 @@
     <link rel="stylesheet" href="popup.css">
     <style>
         /* Safari extension workaround - must use inline styles for body dimensions */
-        html, body {
+        html {
             margin: 0;
             padding: 0;
-            width: 600px;
+            width: 100%;
+            min-width: 600px;
             height: 700px;
         }
-        
+
+        body {
+            margin: 0;
+            padding: 0;
+            width: 100%;
+            height: 100%;
+        }
+
         /* Mobile devices (iPhone) - use device-width instead of viewport width */
         @media only screen and (max-device-width: 600px) {
             html, body {
                 width: 100%;
+                min-width: unset;
                 height: 100vh;
             }
         }

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -7,17 +7,26 @@
     <link rel="stylesheet" href="popup.css">
     <style>
         /* Safari extension workaround - must use inline styles for body dimensions */
-        html, body {
+        html {
             margin: 0;
             padding: 0;
-            width: 600px;
+            width: 100%;
+            min-width: 600px;
             height: 700px;
         }
-        
+
+        body {
+            margin: 0;
+            padding: 0;
+            width: 100%;
+            height: 100%;
+        }
+
         /* Mobile devices (iPhone) - use device-width instead of viewport width */
         @media only screen and (max-device-width: 600px) {
             html, body {
                 width: 100%;
+                min-width: unset;
                 height: 100vh;
             }
         }

--- a/tests/unit/popup.test.js
+++ b/tests/unit/popup.test.js
@@ -334,8 +334,8 @@ describe('Popup UI Tests', () => {
 
     test('should have responsive CSS media queries', () => {
       // iOS Safari対応のレスポンシブデザイン
-      expect(popupHTML).toContain('@media (max-width: 600px)');
-      expect(popupCSS).toContain('@media (max-width: 600px)');
+      expect(popupHTML).toContain('@media only screen and (max-device-width: 600px)');
+      expect(popupCSS).toContain('@media only screen and (max-device-width: 600px)');
       expect(popupCSS).toContain('@media (prefers-contrast: high)');
       expect(popupCSS).toContain('@media (prefers-reduced-motion: reduce)');
     });


### PR DESCRIPTION
Fixes intermittent 608px width issue in macOS Safari popup by using flexible width (100% + min-width) instead of fixed 600px. Resolves #54