### PR TITLE
Refactor CloudKitStore tests to use store API

### DIFF
--- a/Shared (App)/CloudKitStore.swift
+++ b/Shared (App)/CloudKitStore.swift
@@ -14,18 +14,8 @@ class CloudKitStore {
     let modelContext: ModelContext
     let modelContainer: ModelContainer
 
-    private init() {
+    init(inMemory: Bool = false) {
         do {
-            // Local storage setup
-            guard let appGroupURL = FileManager.default.containerURL(
-                forSecurityApplicationGroupIdentifier: "group.com.vocabdict.shared"
-            ) else {
-                fatalError("App Group container URL not found")
-            }
-            try FileManager.default.createDirectory(at: appGroupURL, withIntermediateDirectories: true)
-            let storeURL = appGroupURL.appendingPathComponent("VocabDict.store")
-
-            // Online storage setup
             let schema = Schema([
                 VocabularyList.self,
                 RecentSearchHistory.self,
@@ -33,11 +23,27 @@ class CloudKitStore {
                 DictionaryLookupStats.self,
             ])
 
-            let modelConfiguration = ModelConfiguration(
-                schema: schema,
-                url: storeURL,
-                cloudKitDatabase: .automatic
-            )
+            let modelConfiguration: ModelConfiguration
+            if inMemory {
+                modelConfiguration = ModelConfiguration(
+                    schema: schema,
+                    isStoredInMemoryOnly: true,
+                    cloudKitDatabase: .none
+                )
+            } else {
+                guard let appGroupURL = FileManager.default.containerURL(
+                    forSecurityApplicationGroupIdentifier: "group.com.vocabdict.shared"
+                ) else {
+                    fatalError("App Group container URL not found")
+                }
+                try FileManager.default.createDirectory(at: appGroupURL, withIntermediateDirectories: true)
+                let storeURL = appGroupURL.appendingPathComponent("VocabDict.store")
+                modelConfiguration = ModelConfiguration(
+                    schema: schema,
+                    url: storeURL,
+                    cloudKitDatabase: .automatic
+                )
+            }
 
             modelContainer = try ModelContainer(
                 for: schema,


### PR DESCRIPTION
## Summary
- Refactor CloudKitStore tests to use `CloudKitStore.shared` and its APIs
- Add tests for word updates, duplicate word errors, and spaced repetition intervals via `submitReview`
- Clean up persisted state after each test for isolation
- Allow constructing an in-memory CloudKitStore and use it in tests to avoid CloudKit persistence

## Testing
- `npm run test:all` *(fails: Popup Integration Tests)*
- `npm run test:swift` *(fails: xcodebuild: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b02fa8d644832f97336b0f9cb8cf0d