### PR TITLE
Adjust recent search limit test to expect 20 entries

### DIFF
--- a/vocabDictTests/CloudKitStoreTests.swift
+++ b/vocabDictTests/CloudKitStoreTests.swift
@@ -196,8 +196,8 @@ class CloudKitStoreTests: XCTestCase {
             )
             let searches = try modelContext.fetch(descriptor)
             
-            // Then - Should have all 25, but in practice we'd limit to 20
-            XCTAssertEqual(searches.count, 25)
+            // Then - Should be trimmed to 20 most recent searches
+            XCTAssertEqual(searches.count, 20)
             
             // Verify they're sorted by most recent first
             if searches.count > 1 {


### PR DESCRIPTION
## Summary
- Ensure recent search retrieval trims to 20 items in tests

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68b038fca5f0832fb3d3ef8f248133e2