### PR TITLE
Fix: Right-click context menu 'Look up in VocabDict' functionality

### DIFF
--- a/src/background/background.js
+++ b/src/background/background.js
@@ -71,13 +71,23 @@ async function handleContextMenuClick(info, _tab) {
   if (info.menuItemId === 'lookup-vocabdict' && info.selectionText) {
     console.log('Context menu clicked:', info.selectionText);
 
-    // Use the messaging system for consistency
-    browser.runtime.sendMessage({
-      type: 'open_popup_with_word',
-      word: info.selectionText
-    }).catch(error => {
-      console.error('Error sending context menu message:', error);
-    });
+    // Directly handle the message instead of using sendMessage
+    // This avoids potential issues with Safari's message passing
+    try {
+      const response = await handleMessage({
+        type: 'open_popup_with_word',
+        word: info.selectionText
+      }, services);
+      
+      console.log('Context menu handled with response:', response);
+      
+      if (!response || !response.success) {
+        console.error('Failed to handle context menu click:', response?.error || 'Unknown error');
+      }
+    } catch (error) {
+      console.error('Error handling context menu click:', error);
+      console.error('Error details:', error.message, error.stack);
+    }
   }
 }
 
@@ -90,6 +100,9 @@ if (browser.contextMenus && browser.contextMenus.onClicked) {
  */
 browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
   console.log('Received message:', message);
+  console.log('Message sender:', sender);
+  console.log('Sender URL:', sender?.url);
+  console.log('Sender tab:', sender?.tab);
 
   // Handle the message asynchronously
   handleMessage(message, services)

--- a/tests/background/context-menu-messaging.test.js
+++ b/tests/background/context-menu-messaging.test.js
@@ -1,0 +1,147 @@
+const { handleContextMenuClick, services } = require('../../src/background/background');
+const { handleMessage, MessageTypes } = require('../../src/background/message-handler');
+
+describe('Context Menu Messaging Flow', () => {
+  let originalBrowserAction;
+  let originalSendMessage;
+  let messageHandler;
+
+  beforeEach(() => {
+    // Mock browser.action.openPopup
+    originalBrowserAction = global.browser.action;
+    global.browser.action = {
+      openPopup: jest.fn().mockResolvedValue()
+    };
+
+    // Store original sendMessage
+    originalSendMessage = global.browser.runtime.sendMessage;
+    
+    // Clear any pending searches
+    services.popupWordState.clear();
+
+    // Setup message handler spy
+    messageHandler = jest.fn();
+    
+    // Mock sendMessage to simulate the full message flow
+    global.browser.runtime.sendMessage = jest.fn().mockImplementation(async (message) => {
+      console.log('sendMessage called with:', message);
+      
+      // Simulate the onMessage listener receiving the message
+      const response = await handleMessage(message, services);
+      console.log('handleMessage response:', response);
+      
+      return response;
+    });
+  });
+
+  afterEach(() => {
+    global.browser.action = originalBrowserAction;
+    global.browser.runtime.sendMessage = originalSendMessage;
+    jest.clearAllMocks();
+  });
+
+  test('should handle message directly when context menu is clicked', async () => {
+    const info = {
+      menuItemId: 'lookup-vocabdict',
+      selectionText: 'hello'
+    };
+    const tab = {};
+
+    await handleContextMenuClick(info, tab);
+
+    // Now we directly handle the message, so check the result
+    expect(services.popupWordState.pendingSearch).toBe('hello');
+    expect(browser.action.openPopup).toHaveBeenCalled();
+  });
+
+  test('should handle the full message flow and open popup', async () => {
+    const info = {
+      menuItemId: 'lookup-vocabdict',
+      selectionText: 'hello'
+    };
+    const tab = {};
+
+    // Execute the context menu click
+    await handleContextMenuClick(info, tab);
+
+    // Verify the full flow (now directly handled):
+    // 1. Word was stored in popupWordState
+    expect(services.popupWordState.pendingSearch).toBe('hello');
+
+    // 2. Popup was opened
+    expect(browser.action.openPopup).toHaveBeenCalled();
+  });
+
+  test('should handle OPEN_POPUP_WITH_WORD message directly', async () => {
+    // Test handleMessage directly
+    const result = await handleMessage({
+      type: MessageTypes.OPEN_POPUP_WITH_WORD,
+      word: 'test-word'
+    }, services);
+
+    // Verify success
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({ popupOpened: true });
+
+    // Verify word was stored
+    expect(services.popupWordState.pendingSearch).toBe('test-word');
+
+    // Verify popup was opened
+    expect(browser.action.openPopup).toHaveBeenCalled();
+  });
+
+  test('should handle error when browser.action.openPopup fails', async () => {
+    // Make openPopup fail
+    browser.action.openPopup.mockRejectedValue(new Error('Cannot open popup'));
+
+    const info = {
+      menuItemId: 'lookup-vocabdict',
+      selectionText: 'hello'
+    };
+    const tab = {};
+
+    await handleContextMenuClick(info, tab);
+
+    // Word should still be stored (for manual popup open)
+    expect(services.popupWordState.pendingSearch).toBe('hello');
+    
+    // Popup should have been attempted
+    expect(browser.action.openPopup).toHaveBeenCalled();
+  });
+
+  test('should not process if no text is selected', async () => {
+    const info = {
+      menuItemId: 'lookup-vocabdict',
+      selectionText: ''
+    };
+    const tab = {};
+
+    await handleContextMenuClick(info, tab);
+
+    // Word should not be stored
+    expect(services.popupWordState.pendingSearch).toBeNull();
+
+    // Popup should not be opened
+    expect(browser.action.openPopup).not.toHaveBeenCalled();
+  });
+
+  test('should require word parameter in message', async () => {
+    const result = await handleMessage({
+      type: MessageTypes.OPEN_POPUP_WITH_WORD
+      // Missing word parameter
+    }, services);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Word parameter is required');
+  });
+
+  test('should handle missing popupWordState', async () => {
+    const result = await handleMessage({
+      type: MessageTypes.OPEN_POPUP_WITH_WORD,
+      word: 'test'
+    }, { dictionary: services.dictionary }); // Missing popupWordState
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Popup word state not available');
+  });
+});

--- a/tests/background/context-menu.test.js
+++ b/tests/background/context-menu.test.js
@@ -1,0 +1,87 @@
+const { handleContextMenuClick, services } = require('../../src/background/background');
+
+describe('Context Menu Integration', () => {
+  let originalBrowserAction;
+
+  beforeEach(() => {
+    // Mock browser.action.openPopup
+    originalBrowserAction = global.browser.action;
+    global.browser.action = {
+      openPopup: jest.fn().mockResolvedValue()
+    };
+
+    // Clear any pending searches
+    services.popupWordState.clear();
+  });
+
+  afterEach(() => {
+    global.browser.action = originalBrowserAction;
+  });
+
+  test('should store selected word and open popup when context menu is clicked', async () => {
+    // ユーザーが"hello"という単語を選択して右クリック
+    const info = {
+      menuItemId: 'lookup-vocabdict',
+      selectionText: 'hello'
+    };
+    const tab = {};
+
+    // ユーザーが「Look up in VocabDict」をクリック
+    await handleContextMenuClick(info, tab);
+
+    // 選択した単語が保存される（直接handleMessageを呼ぶため）
+    expect(services.popupWordState.pendingSearch).toBe('hello');
+
+    // ポップアップが開く
+    expect(browser.action.openPopup).toHaveBeenCalled();
+  });
+
+  test('should not process if menu item id does not match', async () => {
+    const info = {
+      menuItemId: 'different-menu-item',
+      selectionText: 'hello'
+    };
+    const tab = {};
+
+    await handleContextMenuClick(info, tab);
+
+    // 単語は保存されない
+    expect(services.popupWordState.pendingSearch).toBeNull();
+
+    // ポップアップも開かない
+    expect(browser.action.openPopup).not.toHaveBeenCalled();
+  });
+
+  test('should not process if no text is selected', async () => {
+    const info = {
+      menuItemId: 'lookup-vocabdict',
+      selectionText: ''
+    };
+    const tab = {};
+
+    await handleContextMenuClick(info, tab);
+
+    // 単語は保存されない
+    expect(services.popupWordState.pendingSearch).toBeNull();
+
+    // ポップアップも開かない
+    expect(browser.action.openPopup).not.toHaveBeenCalled();
+  });
+
+  test('should handle popup open failure gracefully', async () => {
+    // ポップアップが開けない場合をシミュレート
+    browser.action.openPopup.mockRejectedValue(new Error('Cannot open popup'));
+
+    const info = {
+      menuItemId: 'lookup-vocabdict',
+      selectionText: 'hello'
+    };
+    const tab = {};
+
+    // エラーがスローされないことを確認
+    await expect(handleContextMenuClick(info, tab)).resolves.not.toThrow();
+
+    // 単語は保存される（ユーザーが手動でポップアップを開いた時に使える）
+    expect(services.popupWordState.pendingSearch).toBe('hello');
+  });
+});


### PR DESCRIPTION
## Summary
- Fixed the right-click context menu "Look up in VocabDict" feature that wasn't working
- Changed from using `browser.runtime.sendMessage` to directly calling `handleMessage`
- Added comprehensive tests for context menu functionality

## Problem
The context menu was trying to send a message from the background script to itself using `browser.runtime.sendMessage`, which doesn't work by browser design. When a background script calls `sendMessage`, it won't receive the message in its own `onMessage` listener.

## Solution
Instead of using the messaging API, the context menu click handler now directly invokes `handleMessage` with the appropriate parameters. This ensures the popup opens correctly with the selected word.

## Test plan
- [x] Added new test suite for context menu messaging flow
- [x] All 168 tests passing
- [x] Tested that right-click → "Look up in VocabDict" now opens the popup with the selected word

🤖 Generated with [Claude Code](https://claude.ai/code)